### PR TITLE
Remove outline setting for last entity in debug mode

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -195,8 +195,6 @@ end
 
             if entityChanged then options:wipe() end
 
-            if debug and lastEntity > 0 then SetEntityDrawOutline(lastEntity, false) end
-
             hasTarget = false
         end
 


### PR DESCRIPTION
Remove debug outline setting for last entity due to not being implemented into RedM